### PR TITLE
Remove debug logging from reviews API route

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -39,9 +39,6 @@ export async function GET(request: NextRequest) {
 
     const data = await response.json()
     
-    // Debug logging to see what we're getting
-    console.log('Google Places API Response:', JSON.stringify(data, null, 2))
-    
     // The new Places API (New) doesn't have a status field like the old API
     if (!data) {
       throw new Error('No data received from Google Places API')


### PR DESCRIPTION
Removed a debug `console.log` and its comment from `src/app/api/reviews/route.ts` to clean up the code for production. This change was verified manually and via code review.

---
*PR created automatically by Jules for task [11973184367137845506](https://jules.google.com/task/11973184367137845506) started by @Tobiscuit*